### PR TITLE
Cust error

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -587,7 +587,7 @@ func writeItem(e *endpoint, w http.ResponseWriter, r *http.Request, item reflect
 				if customHTTPCode.IsValid() {
 
 					val, ok := customHTTPCode.Interface().(int)
-					if ok {
+					if ok && val != 0 {
 						sendJSON(val)
 						return
 					}


### PR DESCRIPTION
[+] Zero value for HTTPCode from custom-errors ignored
[+] Both the result and error can be nil or zero valued, Incase the result is a zero-valued struct, the same is returned but if it's a nil, success: 1 is returned.
[+] A bug where isNil() was getting called on struct type has been fixed